### PR TITLE
Upgrade to SNAFU 0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7052,18 +7052,18 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+checksum = "d1d4bced6a69f90b2056c03dcff2c4737f98d6fb9e0853493996e1d253ca29c6"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ kstring = { version = "2.0", features = ["max_inline"] }
 itertools = "0.14"
 clap = { version = "4.5", features = ["derive"] }
 mimalloc = "0.1"
-snafu = { version = "0.8.5" }
+snafu = { version = "0.9.0" }
 colog = "1.3.0"
 
 [workspace.lints.rust]

--- a/prescript/src/lib.rs
+++ b/prescript/src/lib.rs
@@ -43,10 +43,8 @@ pub const NOTDEF: &str = ".notdef";
 #[snafu(crate_root(crate))]
 #[snafu(whatever)]
 #[snafu(display("{message}"))]
-#[snafu(provide(opt, ref, chain, dyn std::error::Error => source.as_deref()))]
 pub struct AnyWhatever {
     #[snafu(source(from(Box<dyn Error + Send + Sync>, Some)))]
-    #[snafu(provide(false))]
     source: Option<Box<dyn Error + Send + Sync>>,
     message: String,
     backtrace: Backtrace,


### PR DESCRIPTION
Thanks for using SNAFU! I've just released version 0.9 and my tests caught that your crate would be affected by some of the SemVer-incompatible changes in this version. See the [CHANGELOG][] for a full list.

This commit tries to make the minimal amount of changes to get your code compiling again, but it's entirely possible that there are better solutions for your specific case.

This version also updates the minimum supported Rust version to Rust 1.65 and targets Rust 1.81 by default. I didn't check how these changes affect might your crate, so please make sure to use your judgment as well!

Please feel free to take this PR in whatever form is useful to you; I'm not interested in becoming a long-term contributor to your project, so I'd prefer to not learn your project-specific rules or sign anything like a CLA. I don't mind someone with project approval yoinking these changes and committing it themselves and side-stepping all the red tape.

[CHANGELOG]: https://github.com/shepmaster/snafu/blob/main/CHANGELOG.md#090---2026-03-02